### PR TITLE
e_shstrndx in ELF header defined as ELFXX_Section

### DIFF
--- a/elf/elf.h
+++ b/elf/elf.h
@@ -79,7 +79,7 @@ typedef struct
   Elf32_Half	e_phnum;		/* Program header table entry count */
   Elf32_Half	e_shentsize;		/* Section header table entry size */
   Elf32_Half	e_shnum;		/* Section header table entry count */
-  Elf32_Half	e_shstrndx;		/* Section header string table index */
+  Elf32_Section	e_shstrndx;		/* Section header string table index */
 } Elf32_Ehdr;
 
 typedef struct
@@ -97,7 +97,7 @@ typedef struct
   Elf64_Half	e_phnum;		/* Program header table entry count */
   Elf64_Half	e_shentsize;		/* Section header table entry size */
   Elf64_Half	e_shnum;		/* Section header table entry count */
-  Elf64_Half	e_shstrndx;		/* Section header string table index */
+  Elf64_Section	e_shstrndx;		/* Section header string table index */
 } Elf64_Ehdr;
 
 /* Fields in the e_ident array.  The EI_* macros are indices into the


### PR DESCRIPTION
Elf32/64_Section are typedefs for section indices.
Elf32/64_Ehdr.e_shstrndx is the string table section index, and shall use those typedefs.