### PR TITLE
Update fgetpwent.c

### DIFF
--- a/pwd/fgetpwent.c
+++ b/pwd/fgetpwent.c
@@ -69,6 +69,7 @@ fgetpwent (FILE *stream)
 
       /* Reset the stream.  */
       if (fsetpos (stream, &pos) != 0)
+	free(new_buf);
 	buffer = NULL;
     }
 


### PR DESCRIPTION
new_buf variable is reallocated but when fsetpos() fails, we do not clean it.